### PR TITLE
Remove placeholder if editable area loses focus

### DIFF
--- a/src/js/embeds.js
+++ b/src/js/embeds.js
@@ -103,6 +103,7 @@
         $(document)
             .on('click', $.proxy(this, 'unselectEmbed'))
             .on('keydown', $.proxy(this, 'removeEmbed'))
+            .on('blur', $.proxy(this, 'removePlaceholder'))
             .on('click', '.medium-insert-embeds-toolbar .medium-editor-action', $.proxy(this, 'toolbarAction'))
             .on('click', '.medium-insert-embeds-toolbar2 .medium-editor-action', $.proxy(this, 'toolbar2Action'));
 
@@ -234,9 +235,18 @@
             }
 
         } else {
-            this.$el.find('.medium-insert-embeds-active').remove();
+            this.removePlaceholder();
         }
-    };
+     };
+
+    /**
+     * Removes the placeholder text.
+     *
+     * @return {void}
+     */
+    Embeds.prototype.removePlaceholder = function () {
+      this.$el.find('.medium-insert-embeds-active').remove();
+    }
 
     /**
      * Right click on placeholder in Chrome selects whole line. Fix this by placing caret at the end of line


### PR DESCRIPTION
Cancel editing if editable area loses focus, so that placeholder isn't written into textarea by medium-editor on form submit, if the user doesn't paste or cancel explicitly.